### PR TITLE
Fix HTTP 411 in time offset request (close #11)

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ exports.getTimeOffset = function(callback) {
 	var req = require('https').request({
 		"hostname": "api.steampowered.com",
 		"path": "/ITwoFactorService/QueryTime/v1/",
-		"method": "POST"
+		"method": "POST",
+		"headers": {
+			"Content-Length": 0
+		}
 	}, function(res) {
 		if(res.statusCode != 200) {
 			callback(new Error("HTTP error " + res.statusCode));


### PR DESCRIPTION
The POST request to https://api.steampowered.com/ITwoFactorService/QueryTime/v1/ returns with HTTP status code 411 (Length Required).
By adding...

``` javascript
"headers": {
    "Content-Length": 0
}
```

to the request's options it works.
