### PR TITLE
Use strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 require('@doctormckay/stats-reporter').setup(require('./package.json'));
 
 const Crypto = require('crypto');


### PR DESCRIPTION
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

This happens when you use old npm or meteor.